### PR TITLE
Proposal for using current path if it's not specified for input assembly

### DIFF
--- a/NetReactorSlayer.Core/Utils/Context.cs
+++ b/NetReactorSlayer.Core/Utils/Context.cs
@@ -57,6 +57,9 @@ namespace NETReactorSlayer.Core.Utils
                 FileName = Path.GetFileNameWithoutExtension(path);
                 FileExt = Path.GetExtension(path);
                 FileDir = Path.GetDirectoryName(path);
+                // append current dir if input file was without full path
+                if (FileDir == "")
+                    FileDir = Path.GetDirectoryName(Environment.GetCommandLineArgs()[0]);
                 DestPath = FileDir + "\\" + FileName + "_Slayed" + FileExt;
                 DestName = FileName + "_Slayed" + FileExt;
                 ModuleContext = GetModuleContext();


### PR DESCRIPTION
This is a quick fix for the case when user uses console and does not specify the full path for the input assemlby
the idea is to use the tool's path
